### PR TITLE
Support globs expressions in source paths.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,4 +46,7 @@ Example containing all options enumerated with their default values:
     ~/.ssh/authorized_keys:
        path: 'ssh/authorized_keys'
        fmode: 400
+
+    ~/.ssh/pubkeys/:
+       path: 'ssh/pubkeys/*.pub' # support for glob expressions
 ```

--- a/sync.py
+++ b/sync.py
@@ -69,7 +69,7 @@ class Sync(dotbot.Plugin):
 
                 if len(paths) > 1:
                     self._log.lowinfo(
-                        'Synchronizing expression {}'.format(paths_expression))
+                        'Synchronizing expression {} -> {}'.format(paths_expression, destination))
 
                 for path in paths:
                     success &= self._sync(path, destination, dmode, fmode, owner, group, rsync, options, stdout, stderr)


### PR DESCRIPTION
Adds a feature to process glob expressions in the source path.

Example:
```yaml
    - sync:
        /etc/apt/preferences.d/: 
            path: system/apt/preferences.d/*.pref
            owner: root
            group: root
```

Output:
```
Synchronizing expression system/apt/preferences.d/*.pref
['system/apt/preferences.d/disallow-grub.pref', 'system/apt/preferences.d/disallow-games.pref']
Synchronized /home/jlettman/.dot/system/apt/preferences.d/disallow-grub.pref -> /etc/apt/preferences.d/
['system/apt/preferences.d/disallow-grub.pref', 'system/apt/preferences.d/disallow-games.pref']
Synchronized /home/jlettman/.dot/system/apt/preferences.d/disallow-games.pref -> /etc/apt/preferences.d/
```